### PR TITLE
F/SCO_GO

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Purpose:
+
+
+# Context:
+
+
+# Solution:
+
+
+# Resulting Context:
+
+
+# Future Work:
+

--- a/Makefile
+++ b/Makefile
@@ -408,12 +408,23 @@ generate_gene_distance_plots:
 #-------------------------------------------------------------------#
 # Single Copy Ortholog Analaysis
 # Do genes that are single copy orthologs have lower TE densities than other genes?
+# What are the GO terms associated with single copy ortholog genes?
 
-SSO_TABLE := $(DATA_DIR)/orthologs/single_copy_orthologs/sd01.tsv
+SCO_TABLE := $(DATA_DIR)/orthologs/single_copy_orthologs/sd01.tsv
+SCO_GO_OUTPUT := $(GO_ENRICHMENT_DIR)/Overrepresented_SCO_GO_terms.tsv
 
 .PHONY: single_copy_orthologs
-single_copy_orthologs: $(STRAWBERRY_ORTHOLOG_TABLE) $(SSO_TABLE) $(RESULTS_DIR)
+single_copy_orthologs: $(STRAWBERRY_ORTHOLOG_TABLE) $(SCO_TABLE) $(RESULTS_DIR)
 	python src/orthologs/single_copy_orthologs.py $(DENSITY_TABLE_DIR)/H4_Total_TE_Density_5000_Upstream.tsv $(DENSITY_TABLE_DIR)/RR_Total_TE_Density_5000_Upstream.tsv $^ 
+
+
+# Define a target to run TopGO on the super dense gene output files
+$(SCO_GO_OUTPUT): $(SCO_TABLE) $(TOP_GO_REFERENCE_FILE) 
+	@echo "Running TopGO on single copy orthologs"
+	Rscript $(ROOT_DIR)/src/go_analysis/sco_go.R $(SCO_TABLE) $(TOP_GO_REFERENCE_FILE) $@
+
+.PHONY: generate_sco_go_enrichments
+generate_sco_go_enrichments: $(SCO_GO_OUTPUT)
 
 
 #-------------------------------------------------------------------#

--- a/src/go_analysis/TopGO.R
+++ b/src/go_analysis/TopGO.R
@@ -136,6 +136,7 @@ function_run_topgo = function(master_genes, geneID2GO, my_interesting_genes, ont
 }	
 
 # NEED TO CONVERT THE STRAWBERRY GENES TO ARABIDOPSIS GENES FIRST 
+
 muh_table = function_run_topgo(master_genes, geneID2GO, as.character(strawberry_genes$Arabidopsis_Gene), 'BP', outfile_name)
 
 

--- a/src/go_analysis/generate_gene_w_GO_term.py
+++ b/src/go_analysis/generate_gene_w_GO_term.py
@@ -72,7 +72,7 @@ def generate_go_id_and_term_table(go_master_file):
     return data
 
 
-def read_master_GO_table(go_master_file):
+def transform_to_TopGO_format(go_master_file):
     """
     Take a master GO table from TAIR and preprocess to remove gene IDs we do
     not want. The output is in a format that TopGO desires
@@ -137,7 +137,10 @@ def read_master_GO_table(go_master_file):
     # MAGIC, regex to get AT (1-5) G genes. Don't want mitochondrial or
     # chloroplast or uniquely named genes.
     # I also don't want stuff like YI and XTC...
+    # TODO Check with Pat
+    print(data)
     data = data[data["gene_name"].str.contains("^AT[1-5]G", regex=True)]
+    print(data)
     data = data.sort_values(by=["gene_name"])
 
     return data
@@ -159,9 +162,9 @@ if __name__ == "__main__":
     coloredlogs.install(level=log_level)
     # -----------------------------------------------------------------
 
-    data = read_master_GO_table(args.go_master_file)
-
-    # NOTE this is for TOPGO
+    # NOTE this is for TopGO
+    # This is the gene universe that TopGO wants
+    data = transform_to_TopGO_format(args.go_master_file)
     file_out = os.path.join(args.go_output_path, "ArabidopsisGene_w_GO.tsv")
     logger.info(f"Writing TopGO reference file to: {file_out}")
     data.to_csv(

--- a/src/go_analysis/sco_go.R
+++ b/src/go_analysis/sco_go.R
@@ -1,0 +1,110 @@
+# __author__ Scott Teresi
+# Purpose:
+	# Perform a GO enrichment on a list of Arabidopsis genes pre-identified as
+	# being single-copy orthologs.
+
+# Context:
+	# TODO
+
+suppressPackageStartupMessages(library(topGO))
+suppressPackageStartupMessages(library(dplyr))
+suppressPackageStartupMessages(library(tidyr))
+
+# NOTE not sourcing the other TopGO script, just copying the function because I don't want to run stuff from the main environment.
+# Apparently you can't just source functions, oh well, would have been better to not write stuff in main, but I'm not going to change it now.
+# NOTE future, just write an Rscript that only has functions, don't mix main and functins if you ever want to re-use those functions
+# source('/home/scott/Documents/Uni/Research/Projects/Strawberry_Domestication/src/go_analysis/TopGO.R')
+#---------------------------------------------------------------------#
+# Define input args and do simple set-up
+# Check to see you have the args
+args= commandArgs(trailingOnly=TRUE)
+
+# TODO CHANGE THIS NAME
+sco_arabidopsis_gene_table = read.delim(file=args[1], header=TRUE, sep='\t')
+
+
+# Define your mapping (gene universe), MAGIC input arg 2
+geneID2GO = readMappings(file=args[2], sep='\t') # NB global
+master_genes = names(geneID2GO)  # NB global
+
+# Must be tsv
+outfile = args[3]
+
+my_interesting_genes = sco_arabidopsis_gene_table$gene_id
+
+# NOTE this fuction is copied from TopGO.R
+run_topgo = function(master_genes, geneID2GO, my_interesting_genes, ontology_group){
+	geneList = factor(as.integer(master_genes %in% my_interesting_genes))
+	names(geneList) = master_genes # NB give it names
+
+	GOdata = new('topGOdata',
+		     ontology = ontology_group,
+		     allGenes = geneList,
+		     annot = annFUN.gene2GO,
+		     gene2GO = geneID2GO)
+
+	# NOTE get the number of genes in this interesting list
+	# NOTE how many genes am I losing when I perform this step?
+	# Do some genes not have the 'MF' ontology or something?
+	# print(GOdata)  # NB shows the number of genes lost
+
+	sig_genes = sigGenes(GOdata)  # the significant genes
+	num_sig_genes = numSigGenes(GOdata) # NB the no. of signifcant genes,
+	# not necessarily the nodes in the graph
+	num_nodes = length(usedGO(object=GOdata))  # NB all nodes in the graph,
+	# not necessarily the significant nodes
+	# FUTURE would this be useful information to store?
+
+	resultFisher_weight = runTest(GOdata, algorithm='weight01', statistic='fisher')
+	#resultFisher_classic = runTest(GOdata, algorithm='classic', statistic='fisher')
+
+	# NB from Nolan:
+		# algorithm="classic" WILL NOT take GO hierarchy into account
+	    	# ^ The limitation of using "classic" is that all genes
+       		# annotated to a GO terms will be automatically annotated
+       		# to its parents as well, therefore a GO term might look
+       		# enriched just because its children are enriched
+	    	# algorithm="weight01" WILL take GO hierarchy into account
+		# These p-values have not been corrected for multiple testing
+
+	# NB from Pat:
+       		# After discussion with Pat, since I already have a cutoff applied
+       		# to my modules, and the GO hieracrhy is useful information, I don't want
+       		# to penalize the stats further, so I am going with classic and won't do
+       		# an FDR.
+
+	# list the top significant GO terms
+	# This is for the weight option
+    	allRes = GenTable(GOdata, classicFisher=resultFisher_weight, 
+			  orderBy='classicFisher',
+			  ranksOf='classicFisher',
+			  topNodes=num_nodes,
+			  numChar=1000) # NB avoid truncation of string
+	# This is for classic option
+    	# allRes = GenTable(GOdata, classicFisher=resultFisher_classic, 
+	# 		  orderBy='classicFisher',
+	# 		  ranksOf='classicFisher',
+	# 		  topNodes=num_nodes,
+	# 		  numChar=1000) # NB avoid truncation of string
+			      
+			      
+	# MAGIC p-val threshold
+       	pval_threshold = 0.05
+	
+	# NB apply the p-val threshold
+	allRes_significant = allRes[which(allRes$classicFisher < pval_threshold),]
+
+
+	# NB add a string to a new column that says 'yes' if we have
+       	# more significant than expected
+	allRes_significant$Overrepresented = ifelse(allRes_significant$Significant > allRes_significant$Expected, 'Y', 'N')
+
+	return(allRes_significant)
+
+}	
+
+# Run the function
+muh_table = run_topgo(master_genes, geneID2GO, my_interesting_genes, 'BP')
+# Print to console where I am writing the file
+print(paste('Writing to:', outfile))
+write.table(muh_table, file=file.path(outfile), sep='\t', quote=FALSE, row.names=FALSE)


### PR DESCRIPTION
# Purpose:
Perform a GO enrichment on the single copy ortholog (SCO) genes acquired from a past publication.
We need a little bit of context as to why these SCO genes matter, some people are not as familiar with the evolutionary reasoning behind them (gene dosage and polyploidy) so it would be helpful to have some GO terms we can associate with them to convince them they are important/interesting

# Context:
I created an analysis that compared the TE Density of genes retained as single copy ortholog vs everything else

# Solution:
Take the table and use that as an input for an adjusted TopGO script

# Resulting Context:
Makefile command `generate_sco_go_enrichments`